### PR TITLE
feat: build a debug interface for logging anything

### DIFF
--- a/pkg/log/debug.go
+++ b/pkg/log/debug.go
@@ -1,0 +1,12 @@
+package log
+
+import (
+	"context"
+
+	"github.com/xlgmokha/x/pkg/x"
+)
+
+func Debug[T any](ctx context.Context, item T) T {
+	WithFields(ctx, Fields(x.ToMap(item)))
+	return item
+}

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -78,4 +78,28 @@ func TestLog(t *testing.T) {
 		require.Contains(t, items, "remote_host")
 		assert.Contains(t, items["remote_host"], "127.0.0.1")
 	})
+
+	t.Run("Debug", func(t *testing.T) {
+		t.Run("logs the item and returns it", func(t *testing.T) {
+			var b bytes.Buffer
+			writer := bufio.NewWriter(&b)
+			log := New(writer, Fields{})
+
+			ctx := log.WithContext(t.Context())
+			item := "subject"
+			result := Debug(ctx, item)
+
+			zerolog.Ctx(ctx).Print()
+
+			require.NoError(t, writer.Flush())
+
+			items, err := serde.FromJSON[map[string]string](bufio.NewReader(&b))
+			require.NoError(t, err)
+
+			require.Contains(t, items, "item")
+			assert.Equal(t, "subject", items["item"])
+
+			assert.Equal(t, item, result)
+		})
+	})
 }

--- a/pkg/x/types.go
+++ b/pkg/x/types.go
@@ -36,3 +36,9 @@ func IsSlice[T any](item T) bool {
 func Is[T any](item T, kind reflect.Kind) bool {
 	return reflect.TypeOf(item).Kind() == kind
 }
+
+func ToMap[T any](item T) map[string]interface{} {
+	return map[string]interface{}{
+		"item": item,
+	}
+}

--- a/pkg/x/types_test.go
+++ b/pkg/x/types_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTypes(t *testing.T) {
@@ -148,6 +149,16 @@ func TestTypes(t *testing.T) {
 			assert.True(t, IsPresent[bool](true))
 			assert.True(t, IsPresent[string]("hello"))
 			assert.True(t, IsPresent[*http.Client](&http.Client{}))
+		})
+	})
+
+	t.Run("ToMap", func(t *testing.T) {
+		t.Run("converts a string", func(t *testing.T) {
+			result := ToMap("string")
+
+			require.NotNil(t, result)
+			assert.Contains(t, result, "item")
+			assert.Equal(t, result["item"], "string")
 		})
 	})
 }


### PR DESCRIPTION
# Why is this needed?

This change is inspired by the Rust [dbg!](https://doc.rust-lang.org/std/macro.dbg.html) macro and introduces a way to log any field using the log package.

## What does this do?

It adds a new function to the log package called `log.Debug` that logs the item provided to it and returns it to the caller.

## Type of change

- [x] New feature (non-breaking change which adds functionality)